### PR TITLE
Modify app.rb to read only json files

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -11,7 +11,7 @@ DB_DIRECTORY.freeze
 def memos
   memos = []
   Dir.foreach(DB_DIRECTORY) do |f|
-    if File::Stat.new("#{DB_DIRECTORY}/#{f}").ftype == 'file'
+    if f.match(/.*\.json$/)
       File.open("#{DB_DIRECTORY}/#{f}") do |j|
         memos << JSON.parse(File.read(j))
       end


### PR DESCRIPTION
読み込むファイルの識別方法がファイルか、それ以外かの判定だとjsonのパースエラーになるので、拡張子がjsonのファイルのみを読むように変更。